### PR TITLE
Add the ability in SqlSessionFactoryProvider Builder to set MyBatis Configuration Settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,18 +61,6 @@
             <version>${junit.jupiter.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-            <version>1.9.3</version>
-            <exclusions>
-                <!-- Excluding banned dependency -->
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/cvent/dropwizard/mybatis/sessionbuilder/SqlSessionFactoryProvider.java
+++ b/src/main/java/com/cvent/dropwizard/mybatis/sessionbuilder/SqlSessionFactoryProvider.java
@@ -5,12 +5,11 @@ import com.cvent.dropwizard.mybatis.datasource.ConfigurableLazyDataSourceFactory
 import com.cvent.pangaea.MultiEnvAware;
 import io.dropwizard.db.ManagedDataSource;
 import io.dropwizard.setup.Environment;
-import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.ibatis.reflection.factory.ObjectFactory;
 import org.apache.ibatis.session.SqlSessionFactory;
 
-import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -230,8 +229,10 @@ public final class SqlSessionFactoryProvider {
 
         mybatisConfigurationSettings.forEach((settingName, configSettingObject) -> {
             try {
-                PropertyUtils.setSimpleProperty(sessionFactory.getConfiguration(), settingName, configSettingObject);
-            } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+                Field field = sessionFactory.getConfiguration().getClass().getDeclaredField(settingName);
+                field.setAccessible(true);
+                field.set(sessionFactory.getConfiguration(), configSettingObject);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
                 throw new RuntimeException(e);
             }
         });


### PR DESCRIPTION
As discussed on the java channel, this is a PR which contains the code changes to SqlSessionFactoryProvider Builder, so that it can incorporate MyBatis Configuration Settings while creating session factories.